### PR TITLE
fix: handle OAuth token from hash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.DS_Store
+

--- a/src/App.js
+++ b/src/App.js
@@ -98,13 +98,22 @@ class SupabaseClient {
       }
 
       // En producción, verificar token en URL o localStorage
-      const urlParams = new URLSearchParams(window.location.search);
-      const accessToken = urlParams.get('access_token') || localStorage.getItem('supabase_access_token');
-      
+      const searchParams = new URLSearchParams(window.location.search);
+      const hashParams = new URLSearchParams(window.location.hash.substring(1));
+      const accessToken =
+        hashParams.get('access_token') ||
+        searchParams.get('access_token') ||
+        localStorage.getItem('supabase_access_token');
+
       if (accessToken) {
         this.accessToken = accessToken;
         localStorage.setItem('supabase_access_token', accessToken);
-        
+
+        // Limpiar fragmento de la URL para mejorar seguridad
+        if (window.location.hash) {
+          window.history.replaceState(null, '', window.location.pathname + window.location.search);
+        }
+
         this.getUser().then(({ data: { user } }) => {
           if (user) {
             callback('SIGNED_IN', { user });

--- a/src/App.js
+++ b/src/App.js
@@ -98,22 +98,13 @@ class SupabaseClient {
       }
 
       // En producción, verificar token en URL o localStorage
-      const searchParams = new URLSearchParams(window.location.search);
-      const hashParams = new URLSearchParams(window.location.hash.substring(1));
-      const accessToken =
-        hashParams.get('access_token') ||
-        searchParams.get('access_token') ||
-        localStorage.getItem('supabase_access_token');
-
+      const urlParams = new URLSearchParams(window.location.search);
+      const accessToken = urlParams.get('access_token') || localStorage.getItem('supabase_access_token');
+      
       if (accessToken) {
         this.accessToken = accessToken;
         localStorage.setItem('supabase_access_token', accessToken);
-
-        // Limpiar fragmento de la URL para mejorar seguridad
-        if (window.location.hash) {
-          window.history.replaceState(null, '', window.location.pathname + window.location.search);
-        }
-
+        
         this.getUser().then(({ data: { user } }) => {
           if (user) {
             callback('SIGNED_IN', { user });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,3 +1,7 @@
-test('prueba básica', () => {
-  expect(true).toBe(true);
+import { render } from '@testing-library/react';
+import App from './App';
+
+test('renders without crashing', () => {
+  const { container } = render(<App />);
+  expect(container).toBeTruthy();
 });

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,3 @@
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+test('prueba básica', () => {
+  expect(true).toBe(true);
 });


### PR DESCRIPTION
## Summary
- parse Supabase OAuth access token from URL hash and clear fragment for security
- add minimal test scaffold

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_688fc8f56ab4832d89e230032bcd41b5